### PR TITLE
update to support the latest openresty binary and eventually arm64 architecture.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
-from openresty/openresty:1.11.2.1-centos
+from openresty/openresty:1.25.3.1-2-centos7
 RUN yum install -y libtermcap-devel ncurses-devel libevent-devel readline-devel
-RUN yum install -y lua.x86_64 lua-devel.x86_64 
+RUN yum install -y lua lua-devel 
 Run yum install -y git
 RUN curl -R -O http://luarocks.github.io/luarocks/releases/luarocks-3.9.2.tar.gz
 RUN tar -zxf luarocks-3.9.2.tar.gz && cd luarocks-3.9.2 && \
     ./configure --with-lua-include=/usr/include \
     && make && make install
-RUN luarocks install lua-resty-aws-auth
+RUN luarocks install lua-resty-aws-auth && luarocks install lua-resty-crypto
 COPY ./nginx.conf /usr/local/openresty/nginx/conf/nginx.conf
+# COPY ./lib/resty/aws_auth.lua /usr/local/share/lua/5.1/resty/aws_auth.lua

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ cd lua-resty-aws-auth
 docker build -t lua-resty-aws-auth .
 docker run -d --name nginx -p 8080:8080  -e AWS_ACCESS_KEY_ID=yourkey -e AWS_ACCESS_KEY_SECRET=yoursecret -e AWS_HOST=yourhost:port -e AWS_REGION=us-east-1 -e AWS_SERVICE=s3 lua-resty-aws-auth
 ```
-
+the Dockerfile works both with arm64 and amd64 architectures.
 then you can test the aws service by accessing localhost:8080. Remember to replace the environment variables with your own aws credentials.
 
 actually the backend service can be any s3 compatible service, not only from aws, minio, ceph etc.

--- a/nginx.conf
+++ b/nginx.conf
@@ -61,7 +61,7 @@ http {
 
                 local headers = ngx.req.get_headers()                
                 for k, v in pairs(headers) do
-                    ngx.log(ngx.INFO, "headers before setting", k, ": ", v)
+                    ngx.log(ngx.INFO, "headers before setting: ", k, ": ", v)
                 end
 
                 local config = {
@@ -88,7 +88,7 @@ http {
                 local headers2 = ngx.req.get_headers()
                 
                 for k, v in pairs(headers2) do
-                    ngx.log(ngx.INFO, "headers after setting:", k, ": ", v)
+                    ngx.log(ngx.INFO, "headers after setting: ", k, ": ", v)
                 end
             }
             proxy_pass "http://$backend";


### PR DESCRIPTION
resty.hmac doesn't work with the latest openssl distrubution. replaced with one that works.